### PR TITLE
Added the 'Current' Executor.  Changed the .Primary strategy to .Current

### DIFF
--- a/FutureKit.podspec
+++ b/FutureKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'FutureKit'
-  s.version = '0.8.7'
+  s.version = '0.8.8'
   s.license = 'MIT'
   s.summary = 'A Swift based Future/Promises Library for IOS and OS X.'
   s.homepage = 'https://github.com/FutureKit/FutureKit'

--- a/FutureKit.xcodeproj/project.pbxproj
+++ b/FutureKit.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0D746A4F1AF7FD3C006EEDA2 /* FutureFIFO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D746A4E1AF7FD3C006EEDA2 /* FutureFIFO.swift */; };
+		0D746A501AF7FF14006EEDA2 /* FutureFIFO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D746A4E1AF7FD3C006EEDA2 /* FutureFIFO.swift */; };
 		0D7502B21AE5FD4B009C3F63 /* LockPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D7502B11AE5FD4B009C3F63 /* LockPerformanceTests.swift */; };
 		0D7502B31AE5FD4B009C3F63 /* LockPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D7502B11AE5FD4B009C3F63 /* LockPerformanceTests.swift */; };
 		0D7502B71AE6B114009C3F63 /* FTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D7502B51AE6B114009C3F63 /* FTask.swift */; };
@@ -25,19 +27,21 @@
 		0D7502CE1AE6B29B009C3F63 /* NSFileManager-Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D7502CC1AE6B29B009C3F63 /* NSFileManager-Ext.swift */; };
 		0D7502D01AE6B76D009C3F63 /* NSData-Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D7502CF1AE6B76D009C3F63 /* NSData-Ext.swift */; };
 		0D7502D11AE6B76D009C3F63 /* NSData-Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D7502CF1AE6B76D009C3F63 /* NSData-Ext.swift */; };
+		0DAA4C951B22B3FB0023B02C /* NSOperation+FutureKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DAA4C941B22B3FB0023B02C /* NSOperation+FutureKit.swift */; };
+		0DAA4C961B22B3FB0023B02C /* NSOperation+FutureKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DAA4C941B22B3FB0023B02C /* NSOperation+FutureKit.swift */; };
 		0DEA1B961AE30853000E126F /* FutureKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 0DEA1B951AE30853000E126F /* FutureKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0DEA1BC81AE30885000E126F /* Future.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA41FCE1ADAFE5A00B58B0B /* Future.swift */; };
 		0DEA1BC91AE30885000E126F /* Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DE3AD6F1ADCBBF8000345AD /* Promise.swift */; };
 		0DEA1BCA1AE30885000E126F /* Executor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DE3AD6D1ADCB55C000345AD /* Executor.swift */; };
 		0DEA1BCD1AE30885000E126F /* Synchronization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA41FDA1ADAFEC500B58B0B /* Synchronization.swift */; };
 		0DEA1BD01AE30885000E126F /* FutureBatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DE3AD711ADCBCBA000345AD /* FutureBatch.swift */; };
-		0DEA1BD11AE30885000E126F /* FutureWait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA41FE21ADB483C00B58B0B /* FutureWait.swift */; };
+		0DEA1BD11AE30885000E126F /* SyncWaitHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA41FE21ADB483C00B58B0B /* SyncWaitHandler.swift */; };
 		0DEA1BD51AE30886000E126F /* Future.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA41FCE1ADAFE5A00B58B0B /* Future.swift */; };
 		0DEA1BD61AE30886000E126F /* Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DE3AD6F1ADCBBF8000345AD /* Promise.swift */; };
 		0DEA1BD71AE30886000E126F /* Executor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DE3AD6D1ADCB55C000345AD /* Executor.swift */; };
 		0DEA1BDA1AE30886000E126F /* Synchronization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA41FDA1ADAFEC500B58B0B /* Synchronization.swift */; };
 		0DEA1BDD1AE30886000E126F /* FutureBatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DE3AD711ADCBCBA000345AD /* FutureBatch.swift */; };
-		0DEA1BDE1AE30886000E126F /* FutureWait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA41FE21ADB483C00B58B0B /* FutureWait.swift */; };
+		0DEA1BDE1AE30886000E126F /* SyncWaitHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA41FE21ADB483C00B58B0B /* SyncWaitHandler.swift */; };
 		0DEA1BE51AE30B65000E126F /* FutureKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 0DEA1B951AE30853000E126F /* FutureKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0DEA1BEF1AE3116A000E126F /* FutureKit_iOS_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DEA1BEE1AE3116A000E126F /* FutureKit_iOS_Tests.swift */; };
 		0DEA1BF01AE3116A000E126F /* FutureKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0DEA1B911AE30853000E126F /* FutureKit.framework */; };
@@ -67,6 +71,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0D746A4E1AF7FD3C006EEDA2 /* FutureFIFO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureFIFO.swift; sourceTree = "<group>"; };
 		0D7502B11AE5FD4B009C3F63 /* LockPerformanceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = LockPerformanceTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		0D7502B51AE6B114009C3F63 /* FTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = FTask.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		0D7502BB1AE6B182009C3F63 /* ExtensionVars.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ExtensionVars.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -78,7 +83,8 @@
 		0D7502CF1AE6B76D009C3F63 /* NSData-Ext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "NSData-Ext.swift"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		0DA41FCE1ADAFE5A00B58B0B /* Future.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Future.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		0DA41FDA1ADAFEC500B58B0B /* Synchronization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Synchronization.swift; sourceTree = "<group>"; };
-		0DA41FE21ADB483C00B58B0B /* FutureWait.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = FutureWait.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		0DA41FE21ADB483C00B58B0B /* SyncWaitHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = SyncWaitHandler.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		0DAA4C941B22B3FB0023B02C /* NSOperation+FutureKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSOperation+FutureKit.swift"; sourceTree = "<group>"; };
 		0DB979A01AE2A21100158386 /* BasicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = BasicTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		0DE3AD6D1ADCB55C000345AD /* Executor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Executor.swift; sourceTree = "<group>"; };
 		0DE3AD6F1ADCBBF8000345AD /* Promise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Promise.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -142,6 +148,7 @@
 		0D7502B61AE6B114009C3F63 /* FoundationExtensions */ = {
 			isa = PBXGroup;
 			children = (
+				0DAA4C941B22B3FB0023B02C /* NSOperation+FutureKit.swift */,
 				0D7502CC1AE6B29B009C3F63 /* NSFileManager-Ext.swift */,
 				0D7502CF1AE6B76D009C3F63 /* NSData-Ext.swift */,
 			);
@@ -187,10 +194,11 @@
 			isa = PBXGroup;
 			children = (
 				0DA41FCE1ADAFE5A00B58B0B /* Future.swift */,
+				0D746A4E1AF7FD3C006EEDA2 /* FutureFIFO.swift */,
 				0DE3AD6F1ADCBBF8000345AD /* Promise.swift */,
 				0DE3AD6D1ADCB55C000345AD /* Executor.swift */,
 				0DE3AD711ADCBCBA000345AD /* FutureBatch.swift */,
-				0DA41FE21ADB483C00B58B0B /* FutureWait.swift */,
+				0DA41FE21ADB483C00B58B0B /* SyncWaitHandler.swift */,
 				0DA41FDA1ADAFEC500B58B0B /* Synchronization.swift */,
 				0D7502B91AE6B182009C3F63 /* Utils */,
 				0D7502B41AE6B114009C3F63 /* FTask */,
@@ -450,9 +458,11 @@
 				0DEA1BD01AE30885000E126F /* FutureBatch.swift in Sources */,
 				0D7502B71AE6B114009C3F63 /* FTask.swift in Sources */,
 				0D7502D01AE6B76D009C3F63 /* NSData-Ext.swift in Sources */,
+				0D746A4F1AF7FD3C006EEDA2 /* FutureFIFO.swift in Sources */,
 				0DEA1BCA1AE30885000E126F /* Executor.swift in Sources */,
 				0DEA1BCD1AE30885000E126F /* Synchronization.swift in Sources */,
-				0DEA1BD11AE30885000E126F /* FutureWait.swift in Sources */,
+				0DEA1BD11AE30885000E126F /* SyncWaitHandler.swift in Sources */,
+				0DAA4C951B22B3FB0023B02C /* NSOperation+FutureKit.swift in Sources */,
 				0D7502CD1AE6B29B009C3F63 /* NSFileManager-Ext.swift in Sources */,
 				0D7502C41AE6B182009C3F63 /* NSObject-Ext-ThreadSafe.swift in Sources */,
 				0D7502C81AE6B182009C3F63 /* ObjectiveCExceptionHandler.m in Sources */,
@@ -470,9 +480,11 @@
 				0DEA1BDD1AE30886000E126F /* FutureBatch.swift in Sources */,
 				0D7502B81AE6B114009C3F63 /* FTask.swift in Sources */,
 				0D7502D11AE6B76D009C3F63 /* NSData-Ext.swift in Sources */,
+				0D746A501AF7FF14006EEDA2 /* FutureFIFO.swift in Sources */,
 				0DEA1BD71AE30886000E126F /* Executor.swift in Sources */,
 				0DEA1BDA1AE30886000E126F /* Synchronization.swift in Sources */,
-				0DEA1BDE1AE30886000E126F /* FutureWait.swift in Sources */,
+				0DEA1BDE1AE30886000E126F /* SyncWaitHandler.swift in Sources */,
+				0DAA4C961B22B3FB0023B02C /* NSOperation+FutureKit.swift in Sources */,
 				0D7502CE1AE6B29B009C3F63 /* NSFileManager-Ext.swift in Sources */,
 				0D7502C51AE6B182009C3F63 /* NSObject-Ext-ThreadSafe.swift in Sources */,
 				0D7502C91AE6B182009C3F63 /* ObjectiveCExceptionHandler.m in Sources */,

--- a/FutureKit/FoundationExtensions/NSOperation+FutureKit.swift
+++ b/FutureKit/FoundationExtensions/NSOperation+FutureKit.swift
@@ -1,0 +1,109 @@
+//
+//  NSOperation+FutureKit.swift
+//  Shimmer
+//
+//  Created by Michael Gray on 6/2/15.
+//  Copyright (c) 2015 FlybyMedia. All rights reserved.
+//
+
+import Foundation
+
+
+class FutureOperation<T> : _FutureAnyOperation {
+    
+    class func OperationWithBlock(block b: () -> Future<T>) -> FutureOperation<T> {
+        return FutureOperation<T>(block:b)
+    }
+    
+    var future : Future<T> {
+        return self.promise.future.As()
+    }
+
+    init(block b: () -> Future<T>) {
+        super.init(block: { () -> FutureProtocol in
+            return b()
+        })
+    }
+    
+}
+
+
+class _FutureAnyOperation : NSOperation, FutureProtocol {
+    
+    private var getSubFuture : () -> FutureProtocol
+    var subFuture : Future<Any>?
+    var cancelToken : CancellationToken?
+    
+    var promise = Promise<Any>()
+    
+    override var asynchronous : Bool {
+        return true
+    }
+    
+    private var _is_executing : Bool {
+        willSet {
+            self.willChangeValueForKey("isExecuting")
+        }
+        didSet {
+            self.didChangeValueForKey("isExecuting")
+        }
+    }
+    private var _is_finished : Bool {
+        willSet {
+            self.willChangeValueForKey("isFinished")
+        }
+        didSet {
+            self.didChangeValueForKey("isFinished")
+        }
+    }
+    
+    override var executing : Bool {
+        return _is_executing
+    }
+    
+    override var finished : Bool {
+        return _is_finished
+    }
+    
+    init(block : () -> FutureProtocol) {
+        self.getSubFuture = block
+        self._is_executing = false
+        self._is_finished = false
+        super.init()
+    }
+    
+    override func main() {
+        
+        if self.cancelled {
+            self._is_executing = false
+            self._is_finished = true
+            self.promise.completeWithCancel()
+            return
+        }
+        
+        self._is_executing = true
+
+        let f : Future<Any> = self.getSubFuture().As()
+        self.subFuture = f
+        self.cancelToken = f.getCancelToken()
+        f.onComplete { completion in
+            self._is_executing = false
+            self._is_finished = true
+            self.promise.complete(completion)
+        }
+        
+    }
+    override func cancel() {
+        super.cancel()
+        self.cancelToken?.cancel()
+    }
+    
+    func As<S>() -> Future<S> {
+        return self.promise.future.As()
+    }
+    
+    func convertOptional<S>() -> Future<S?> {
+        return self.promise.future.convertOptional()
+    }
+    
+}

--- a/FutureKit/FutureBatch.swift
+++ b/FutureKit/FutureBatch.swift
@@ -38,6 +38,7 @@ public class FutureBatchOf<T> {
     
     */
     internal(set) var subFutures  = [Future<T>]()
+    private var tokens = [CancellationToken]()
 
     /** 
         `completionsFuture` returns an array of individual Completion<T> values
@@ -66,6 +67,11 @@ public class FutureBatchOf<T> {
     */
     public init(f : [Future<T>]) {
         self.subFutures = f
+        for s in self.subFutures {
+            if let t = s.getCancelToken() {
+                self.tokens.append(t)
+            }
+        }
         self.completionsFuture = FutureBatchOf.completionsFuture(f)
     }
     
@@ -90,9 +96,9 @@ public class FutureBatchOf<T> {
         will forward a cancel request to each subFuture
         Doesn't guarantee that a particular future gets canceled
     */
-    func cancel() {
-        for f in self.subFutures {
-            f.cancel()
+    func cancel(forced:Bool = false) {
+        for t in self.tokens {
+            t.cancel(forced:forced)
         }
     }
     

--- a/FutureKit/FutureFIFO.swift
+++ b/FutureKit/FutureFIFO.swift
@@ -1,0 +1,53 @@
+//
+//  FutureFIFO.swift
+//  FutureKit
+//
+//  Created by Michael Gray on 5/4/15.
+//  Copyright (c) 2015 Michael Gray. All rights reserved.
+//
+
+import Foundation
+
+
+// can execute a FIFO set of Blocks and Futures, guaranteeing that Blocks and Futures execute in order
+public class FutureFIFO {
+    
+    private var lastFuture = Future<Void>(success: ())
+    
+    
+    // add a block and it won't execute until all previosuly submitted Blocks have finished and returned a result.
+    // If the block returns a result, than the next ask in the queue is started.
+    // If the block returns a Task, that Task must complete before the next block in the Queue is executed.
+    
+    // A Failed or Canceled task doesn't stop execution of the queue
+    // If you care about the Result of specific committed block, you can add a dependency to the Task returned from this function
+    public final func addBlock<__Type>(executor: Executor, _ block: () -> __Type) -> Future<__Type> {
+        
+        let t = self.lastFuture.onComplete (executor) { (completion) -> __Type in
+            return block()
+        }
+        self.lastFuture = t.As()
+        return t
+    }
+
+    public final func addBlock<__Type>(block: () -> __Type) -> Future<__Type> {
+        
+        return self.addBlock(.Primary,block)
+    }
+
+    public final func addBlock<__Type>(executor: Executor, _ block: () -> Future<__Type>) -> Future<__Type> {
+    
+        let t = self.lastFuture.onComplete { (completion) -> Future<__Type> in
+            return block()
+        }
+        self.lastFuture = t.As()
+        return t
+    }
+
+    public final func addBlock<__Type>(block: () -> Future<__Type>) -> Future<__Type> {
+        
+        return self.addBlock(.Primary,block)
+    }
+    
+
+}

--- a/FutureKit/SyncWaitHandler.swift
+++ b/FutureKit/SyncWaitHandler.swift
@@ -25,10 +25,10 @@
 import Foundation
 
 public func warnOperationOnMainThread() {
-    NSLog("Warning: A long-running Future wait operation is being executed on the main thread. \n Break on warnOperationOnMainThread() to debug.")
+    NSLog("Warning: A long-running Future wait operation is being executed on the main thread. \n Break on FutureKit.warnOperationOnMainThread() to debug.")
 }
 
-class FutureWaitHandler<T>  {
+class SyncWaitHandler<T>  {
     
     private var condition : NSCondition = NSCondition()
     

--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ http://en.wikipedia.org/wiki/Futures_and_promises
 
 FutureKit sues Swift generic classes, to allow you to easily deal with asynchronous/multi-threaded issues when coding for iOS or OSX.
 
-FutureKit is ALMOST ready to be used.  This is the "eval" version.  Please look around and tell us what you think.  A lot of work went into it so far, but we are ready to start showing it off.  We are STILL making changes, (changes in nomenclature, logic, etc.).  And trying to get all the code documented (using XCode 6.3 built in markdown).  This is a really good version, and feel free to play around.  But there is a good chance we are make some source-code-breaking changes in the next few weeks.  So don't say I didn't warn you.  This file will officially tell you when we think we have hit "1.0".   
+FutureKit is heading for beta! 
 
-The goal is to have a working version out before the end of May, with the official 1.0 release ready for WWDC 2015. (no.. I didn't get a ticket either)
+We are almost feature complete.  The Cancellation strategy looks finalized.  Still some additional test coverage to finish.  
 
-All of the primary Swift code is written. (And works!)  But we are still tweaking things and trying to get to tests written that cover all the critical versions.
+Feel free to try it out.   I'm hoping to have a few sub-frameworks for adding FutureKit extensions to a few other Swift libraries (AlamoFire, Haneke) soon also.  
+
 
 - is 100% Swift.  It ONLY currently supports Swift 1.2 and XCode 6.3.  No Swift 1.1 support.  I have currently only been testing using iOS 8.0+.  The plan will be to fix compatibility issues with iOS 7.0.  But I wouldn’t be surprised if things break every know and then.  If you find a problem - submit an issue please!
 


### PR DESCRIPTION
simplified the .Custom() executor.

Re-wrote the cancellation to be Source/Token based.    Cancellation works even with Future composition (in most cases).

Support 'forced' cancel, where any future can cancel the future it depends on, even if there are other futures waiting for completion.

Added FutureFIFO - force futures to execute once a time, in order.

If you need Concurrent Future execution, look at the NSOperation+Future extension, and use a NSOperationQueue()

Added the promise.onRequestCancel() to add cancellation support to a Promise/Future.

Added a read() operation to SynchronizationProtocol, where you want to do a read_only operation but don't need to return any data.

`