### PR TITLE
Fixes a critical bug in the .Current Executor logic

### DIFF
--- a/FutureKit OSX Tests/Info.plist
+++ b/FutureKit OSX Tests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.futurekit.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/FutureKit iOS Tests/Info.plist
+++ b/FutureKit iOS Tests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.futurekit.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/FutureKit-1. Future.playground/Contents.swift
+++ b/FutureKit-1. Future.playground/Contents.swift
@@ -16,7 +16,7 @@ let resultOfFuture5 = future5Int.result!
 //: Sometimes a Future will fail. Maybe the database is all out if 5's.  So instead of 5, we are gonna return a failure.  No number 5 for you.
 let futureFail = Future<Int>(failWithErrorMessage:"I have no 5's for you today.")
 let failed5result = futureFail.result
-let e = futureFail.error!.localizedDescription
+let e = futureFail.error
 //: Sometimes your request is cancelled. It's not usually because of a failure, and usually means we just wanted to halt an async process before it was done.  Optionally you can send a reason, but it's not required.  In FutureKit a Fail means that something went wrong, and you should cope with that.  a Cancel is usually considered "legal", like canceling active API requests when a window is closed.
 let cancelledFuture = Future<Int>(cancelled: ())
 let cancelledResult = cancelledFuture.result
@@ -58,7 +58,7 @@ let f = asyncFuture5.onSuccess(.Main) { (result) -> Void in
 //: We can also add handlers for Fail and Cancel:
 
 futureFail.onFail { (error) -> Void in
-    let e = error.localizedDescription
+    let e = "\(error)"
 }
 
 cancelledFuture.onCancel { () -> Void in
@@ -83,5 +83,3 @@ let completionOfAsyncFuture5 = asyncFuture5.completion!
 // ".Success(5)"
 
 //: Seems easy?  Let's make them more fun.. (next Playground!)
-
-

--- a/FutureKit-2. Promise.playground/Contents.swift
+++ b/FutureKit-2. Promise.playground/Contents.swift
@@ -43,14 +43,14 @@ func getCoolCatPic(url: NSURL) -> Future<UIImage> {
     
     // go get data from this URL.
     let task = NSURLSession.sharedSession().dataTaskWithURL(url, completionHandler: { (data, response, error) -> Void in
-        let r = response
         if let e = error {
             // if this is failing, make sure you aren't running this as an iOS Playground. It works when running as an OSX Playground.
             catPicturePromise.completeWithFail(e)
         }
         else {
             // parsing the data from the server into an Image.
-            if let image = UIImage(data: data) {
+            if let d = data,
+                let image = UIImage(data: d) {
                 let i = image
                 catPicturePromise.completeWithSuccess(i)
             }

--- a/FutureKit.podspec
+++ b/FutureKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'FutureKit'
-  s.version = '0.8.8'
+  s.version = '0.8.9'
   s.license = 'MIT'
   s.summary = 'A Swift based Future/Promises Library for IOS and OS X.'
   s.homepage = 'https://github.com/FutureKit/FutureKit'

--- a/FutureKit.xcodeproj/project.pbxproj
+++ b/FutureKit.xcodeproj/project.pbxproj
@@ -635,6 +635,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.futurekit.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = FutureKit;
 				SKIP_INSTALL = YES;
 			};
@@ -652,6 +653,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.futurekit.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = FutureKit;
 				SKIP_INSTALL = YES;
 			};
@@ -676,6 +678,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.futurekit.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = FutureKit;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -696,6 +699,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.futurekit.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = FutureKit;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -715,6 +719,7 @@
 				);
 				INFOPLIST_FILE = "FutureKit iOS Tests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.futurekit.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -728,6 +733,7 @@
 				);
 				INFOPLIST_FILE = "FutureKit iOS Tests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.futurekit.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -748,6 +754,7 @@
 				INFOPLIST_FILE = "FutureKit OSX Tests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.futurekit.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 			};
@@ -764,6 +771,7 @@
 				INFOPLIST_FILE = "FutureKit OSX Tests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.futurekit.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 			};

--- a/FutureKit/Executor.swift
+++ b/FutureKit/Executor.swift
@@ -543,13 +543,6 @@ public enum Executor {
             return Executor.AsyncExecutor.real_executor
         case .Current:
             return Executor.SmartCurrent
-        case .MainImmediate:
-            if (NSThread.isMainThread()) {
-                return .Immediate
-            }
-            else {
-                return .MainAsync
-            }
         case let .ManagedObjectContext(context):
             if (context.concurrencyType == .MainQueueConcurrencyType) {
                 return Executor.MainExecutor.real_executor

--- a/FutureKit/FTask/FTask.swift
+++ b/FutureKit/FTask/FTask.swift
@@ -167,7 +167,7 @@ extension FTaskPromise : Printable, DebugPrintable {
     
 //    case ManagedObjectContext(NSManagedObjectContext)   // block will run inside the managed object's context via context.performBlock()
     
-    func execute<T>(block b: dispatch_block_t) {
+    func execute(block b: dispatch_block_t) {
         let executionBlock = self.executor().callbackBlockFor(b)
         executionBlock()
     }

--- a/FutureKit/FoundationExtensions/NSData-Ext.swift
+++ b/FutureKit/FoundationExtensions/NSData-Ext.swift
@@ -38,7 +38,7 @@ extension NSData {
     
     alternative use `class func data(executor : Executor, contentsOfFile path: String, options readOptionsMask: NSDataReadingOptions)`
     
-    :returns: an Future<NSData>
+    - returns: an Future<NSData>
     */
     class func data(executor : Executor, contentsOfFile path: String, options readOptionsMask: NSDataReadingOptions) -> Future<NSData> {
         
@@ -65,7 +65,7 @@ extension NSData {
     
     alternative use `class func data(executor : Executor, contentsOfFile path: String, options readOptionsMask: NSDataReadingOptions)`
     
-    :returns: an Future<NSData>
+    - returns: an Future<NSData>
     */
     class func data(contentsOfFile path: String, options readOptionsMask: NSDataReadingOptions) -> Future<NSData> {
         return self.data(.Async, contentsOfFile: path, options: readOptionsMask)
@@ -85,7 +85,7 @@ extension NSData {
                     }
     
     
-    :returns: an Future<NSData>
+    - returns: an Future<NSData>
     */
     class func data(executor : Executor, contentsOfURL url: NSURL, options readOptionsMask: NSDataReadingOptions) -> Future<NSData> {
         
@@ -111,7 +111,7 @@ extension NSData {
     uses `Executor.Async` to read from path.  The default configuration of Executor.Async is QOS_CLASS_DEFAULT.
     
     alternative use `class func data(executor : Executor, contentsOfFile path: String, options readOptionsMask: NSDataReadingOptions)`
-    :returns: an Future<NSData>
+    - returns: an Future<NSData>
     */
     class func data(contentsOfURL url: NSURL, options readOptionsMask: NSDataReadingOptions) -> Future<NSData> {
         return self.data(.Async, contentsOfURL: url, options: readOptionsMask)
@@ -124,13 +124,13 @@ extension NSData {
     
     alternative use `class func data(executor : Executor, contentsOfFile path: String, options readOptionsMask: NSDataReadingOptions)`
     
-    :returns: an Future<NSData>
+    - returns: an Future<NSData>
     */
     class func data(executor : Executor, contentsOfURL url: NSURL) -> Future<NSData> {
         
         let promise = Promise<NSData>()
         executor.execute { () -> Void in
-            var error : NSError?
+            
             let data = NSData(contentsOfURL: url)
             if let d = data {
                 promise.completeWithSuccess(d)
@@ -146,7 +146,7 @@ extension NSData {
     
     uses `Executor.Async` to read from path.  The default configuration of Executor.Async is QOS_CLASS_DEFAULT.
     
-    :returns: an Future<NSData>.  Fails of NSData(contentsOfUrl:url) returns a nil.
+    - returns: an Future<NSData>.  Fails of NSData(contentsOfUrl:url) returns a nil.
     */
     class func data(contentsOfURL url: NSURL) -> Future<NSData> {
         return self.data(.Async, contentsOfURL: url)

--- a/FutureKit/Info.plist
+++ b/FutureKit/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.futurekit.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/FutureKit/Promise.swift
+++ b/FutureKit/Promise.swift
@@ -119,12 +119,16 @@ public class Promise<T>  {
     public final func completeWithSuccess(result : T) {
         self.future.completeWith(.Success(Result(result)))
     }
-    public final func completeWithFail(e : NSError) {
-        self.future.completeWith(.Fail(e))
-    }
+//    public final func completeWithFail(e : NSError) {
+//        self.future.completeWith(.Fail(e))
+//    }
     public final func completeWithFail(errorMessage : String) {
         self.future.completeWith(Completion<T>(failWithErrorMessage: errorMessage))
     }
+    public final func completeWithFail(error : ErrorType) {
+        self.future.completeWith(Completion<T>(failWithErrorMessage: "\(error)"))
+    }
+
     public final func completeWithException(e : NSException) {
         self.future.completeWith(Completion<T>(exception: e))
     }
@@ -134,6 +138,16 @@ public class Promise<T>  {
     public final func continueWithFuture(f : Future<T>) {
         self.future.completeWith(.CompleteUsing(f))
     }
+    
+/*    public final func completeWithThrowingBlock(block: () throws -> T) {
+        do {
+            let t = try block()
+            self.completeWithSuccess(t)
+        }
+        catch {
+            self.completeWithFail(error)
+        }
+    } */
 
     /**
     completes the Future using the supplied completionBlock.
@@ -144,7 +158,7 @@ public class Promise<T>  {
 
     if you need to know if the completion was successful, use 'completeWithBlocks()'
     
-    :param: completionBlock a block that will run iff the future has not yet been completed.  It must return a completion value for the promise.
+    - parameter completionBlock: a block that will run iff the future has not yet been completed.  It must return a completion value for the promise.
     */
     public final func completeWithBlock(completionBlock : ()->Completion<T>) {
         self.future.completeWithBlocks(completionBlock,onCompletionError: nil)
@@ -159,9 +173,9 @@ public class Promise<T>  {
     
     These blocks may end up running inside any potential thread or queue, so avoid using external/shared memory.
 
-    :param: completionBlock a block that will run iff the future has not yet been completed.  It must return a completion value for the promise.
+    - parameter completionBlock: a block that will run iff the future has not yet been completed.  It must return a completion value for the promise.
 
-    :param: onAlreadyCompleted a block that will run iff the future has already been completed. 
+    - parameter onAlreadyCompleted: a block that will run iff the future has already been completed. 
     */
     public final func completeWithBlocks(completionBlock : ()->Completion<T>, onAlreadyCompleted : () -> Void)
     {

--- a/FutureKit/Synchronization.swift
+++ b/FutureKit/Synchronization.swift
@@ -322,7 +322,7 @@ class NSObjectLockSynchronization : SynchronizationProtocol {
 
 func synchronizedWithLock<T>(l: NSLocking, @noescape closure:  ()->T) -> T {
     l.lock()
-    var retVal: T = closure()
+    let retVal: T = closure()
     l.unlock()
     return retVal
 }
@@ -369,7 +369,7 @@ public class NSLockSynchronization : SynchronizationProtocol {
 
 func synchronizedWithSpinLock<T>(l: UnSafeMutableContainer<OSSpinLock>, @noescape closure:  ()->T) -> T {
     OSSpinLockLock(l.unsafe_pointer)
-    var retVal: T = closure()
+    let retVal: T = closure()
     OSSpinLockUnlock(l.unsafe_pointer)
     return retVal
 }
@@ -550,7 +550,7 @@ class CollectionAccessControl<C : MutableCollectionType, S: SynchronizationProto
         }
     }
     
-    subscript (key: Index) -> Element {
+/*    subscript (key: Index) -> Element {
         get {
             return self.syncObject.readSync { () -> Element in
                 return self.collection[key]
@@ -561,7 +561,7 @@ class CollectionAccessControl<C : MutableCollectionType, S: SynchronizationProto
                 self.collection[key] = newValue
             }
         }
-    }
+    } */
 
 }
 
@@ -607,7 +607,7 @@ class DictionaryAccessControl<Key : Hashable, Value, S: SynchronizationProtocol>
         }
     }
 
-    subscript (key: Key) -> Value? {
+/*    subscript (key: Key) -> Value? {
         get {
             return self.syncObject.readSync { () -> Element? in
                 return self.dictionary[key]
@@ -618,7 +618,7 @@ class DictionaryAccessControl<Key : Hashable, Value, S: SynchronizationProtocol>
                 self.dictionary[key] = newValue
             }
         }
-    }
+    } */
 }
 
 
@@ -670,11 +670,11 @@ class ArrayAccessControl<T, S: SynchronizationProtocol> : CollectionAccessContro
         }
     }
     
-    subscript (future index: Int) -> Future<T> {
+/*    subscript (future index: Int) -> Future<T> {
         return self.syncObject.readFuture { () -> T in
             return self.collection[index]
         }
-    }
+    } */
 
     
     func getValue(atIndex i: Int) -> Future<T> {

--- a/FutureKit/Utils/ExtensionVars.swift
+++ b/FutureKit/Utils/ExtensionVars.swift
@@ -259,7 +259,7 @@ extension __ExampleClass {
 
 func _someExampleStuffs() {
     
-    var e = __ExampleClass()
+    let e = __ExampleClass()
     e.regularVar = 22   // this isn't an extension var, but defined in the original class
     
     assert(e.intWithDefaultValue == 55, "default values should work!")

--- a/FutureKit/Utils/NSObject-Ext-ThreadSafe.swift
+++ b/FutureKit/Utils/NSObject-Ext-ThreadSafe.swift
@@ -38,7 +38,7 @@ extension NSObject {
     func SAFER_THREAD_SAFE_SYNC<T>(@noescape closure: ()->T) -> T
     {
         objc_sync_enter(self.lockObject)
-        var retVal: T = closure()
+        let retVal: T = closure()
         objc_sync_exit(self.lockObject)
         return retVal
     }
@@ -46,7 +46,7 @@ extension NSObject {
     func EFFICIENT_THREAD_SAFE_SYNC<T>(@noescape closure: ()->T) -> T
     {
         objc_sync_enter(self)
-        var retVal: T = closure()
+        let retVal: T = closure()
         objc_sync_exit(self)
         return retVal
     }
@@ -68,7 +68,7 @@ extension NSObject {
 
 func SYNCHRONIZED<T>(lock: AnyObject, @noescape closure:  ()->T) -> T {
     objc_sync_enter(lock)
-    var retVal: T = closure()
+    let retVal: T = closure()
     objc_sync_exit(lock)
     return retVal
 }

--- a/FutureKitTests/BasicTests.swift
+++ b/FutureKitTests/BasicTests.swift
@@ -53,9 +53,8 @@ func iWillKeepTryingTillItWorks(var attemptNo: Int) -> Future<(tries:Int,result:
         switch completion {
         case let .Success(yay):
             // Success uses Any as a payload type, so we have to convert it here.
-            let s = yay as! String
-            let result = (attemptNo,s)
-            return .Success(result)
+            let result = (tries:attemptNo,result:yay.result)
+            return SUCCESS(result)
         default: // we didn't succeed!
             let nextFuture = iWillKeepTryingTillItWorks(attemptNo)
             return .CompleteUsing(nextFuture)
@@ -106,8 +105,7 @@ class FutureKitBasicTests: XCTestCase {
     func testADoneFutureExpectation() {
         let val = 5
         
-        let f = Future<Int>(success: val)
-        var ex = f.expectationTestForSuccess(self, "AsyncMadness") { (result) -> BooleanType in
+        Future<Int>(success: val).expectationTestForSuccess(self, "AsyncMadness") { (result) -> BooleanType in
             return (result == val)
         }
         
@@ -117,9 +115,7 @@ class FutureKitBasicTests: XCTestCase {
     }
     func testContinueWithRandomly() {
         
-        let f = iWillKeepTryingTillItWorks(0)
- 
-        var ex = f.expectationTestForAnySuccess(self, "Description")
+        iWillKeepTryingTillItWorks(0).expectationTestForAnySuccess(self, "Description")
         
         self.waitForExpectationsWithTimeout(120.0, handler: nil)
         

--- a/FutureKitTests/Future-TestExtensions.swift
+++ b/FutureKitTests/Future-TestExtensions.swift
@@ -54,9 +54,9 @@ extension Future {
                 case .Success:
                     let result = completion.result
                     return (test(result: result),"test result failure for Future with result \(result)" )
-                case let .Fail:
+                case .Fail:
                     let e = completion.error
-                    return (false,"Future Failed with \(e) \(e.localizedDescription)" )
+                    return (false,"Future Failed with \(e)" )
                 case .Cancelled:
                     return (false,"Future Cancelled" )
                 }
@@ -74,7 +74,7 @@ extension Future {
                     return (true, "")
                 case .Fail:
                     let e = completion.error
-                    return (false,"Future Failed with \(e) \(e.localizedDescription)" )
+                    return (false,"Future Failed with \(e)" )
                 case .Cancelled:
                     return (false,"Future Cancelled" )
                 }

--- a/FutureKitTests/LockPerformanceTests.swift
+++ b/FutureKitTests/LockPerformanceTests.swift
@@ -25,8 +25,8 @@
 import XCTest
 import FutureKit
 
-let executor = Executor.createConcurrentQueue(label: "FuturekitTests")
-let executor2 = Executor.createConcurrentQueue(label: "FuturekitTests2")
+let executor = Executor.createConcurrentQueue("FuturekitTests")
+let executor2 = Executor.createConcurrentQueue("FuturekitTests2")
 
 
 
@@ -104,11 +104,9 @@ class FutureKitLockPerformanceTests: XCTestCase {
     func doATestCase(lockStategy: SynchronizationType, chaining : Bool, x : Int, y: Int, iterations : Int) {
         
         GLOBAL_PARMS.LOCKING_STRATEGY = lockStategy
-        GLOBAL_PARMS.BATCH_FUTURES_WITH_CHAINING = chaining
+//        GLOBAL_PARMS.BATCH_FUTURES_WITH_CHAINING = chaining
         
-        let f = divideAndConquer(.Primary,x,y,iterations)
-        
-        var ex = f.expectationTestForSuccess(self, "Description") { (result) -> BooleanType in
+        divideAndConquer(.Primary,x,y,iterations).expectationTestForSuccess(self, "Description") { (result) -> BooleanType in
             return (result == (x+y)*iterations)
         }
         


### PR DESCRIPTION
Also: 

We took a "round trip" to the Swift 2.0 converter in XCode 7b1 and came back to XCode 6.3.2.  This code is STILL Swift 1.2 compatible.  But the Swift 2.0 convertor found lots of optimizations that I ported back to swift 1.2
That's gonna make the final Swift 2.0 branch a little easier to deal with.  (Swift 2.0 branch coming soon!)

We are moving the .Error completion value from an NSError associated type to an ErrorType associated type.  And for convenience, ErrorType will 'alias' NSError on Swift 1.2

Coming soon:  Promise that can complete with a 'throwable' block to make Future error handling SUPER EASY in Swift 1.2  (you don't have to catch things yourself!)