### PR TITLE
Feature/better failure handlers

### DIFF
--- a/FutureKit.xcodeproj/project.pbxproj
+++ b/FutureKit.xcodeproj/project.pbxproj
@@ -7,12 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		090112C11BD851CB002EB82D /* Tuples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 090112C01BD851CB002EB82D /* Tuples.swift */; settings = {ASSET_TAGS = (); }; };
-		090112C21BD851CB002EB82D /* Tuples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 090112C01BD851CB002EB82D /* Tuples.swift */; settings = {ASSET_TAGS = (); }; };
-		09059C411BB20A6E00555E26 /* BasicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB979A01AE2A21100158386 /* BasicTests.swift */; settings = {ASSET_TAGS = (); }; };
-		09059C421BB20A8800555E26 /* PromiseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBDAD3E1B3C5A78004310B9 /* PromiseTests.swift */; settings = {ASSET_TAGS = (); }; };
-		092794BC1BB25DD300DFB56D /* Completion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092794BB1BB25DD300DFB56D /* Completion.swift */; settings = {ASSET_TAGS = (); }; };
-		092794BD1BB25DD300DFB56D /* Completion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092794BB1BB25DD300DFB56D /* Completion.swift */; settings = {ASSET_TAGS = (); }; };
+		090112C11BD851CB002EB82D /* Tuples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 090112C01BD851CB002EB82D /* Tuples.swift */; };
+		090112C21BD851CB002EB82D /* Tuples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 090112C01BD851CB002EB82D /* Tuples.swift */; };
+		09059C411BB20A6E00555E26 /* BasicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB979A01AE2A21100158386 /* BasicTests.swift */; };
+		09059C421BB20A8800555E26 /* PromiseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBDAD3E1B3C5A78004310B9 /* PromiseTests.swift */; };
+		092794BC1BB25DD300DFB56D /* Completion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092794BB1BB25DD300DFB56D /* Completion.swift */; };
+		092794BD1BB25DD300DFB56D /* Completion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092794BB1BB25DD300DFB56D /* Completion.swift */; };
 		0D2C4F4A1B2A00C20090765F /* XCTestCase-Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D2C4F491B2A00C20090765F /* XCTestCase-Ext.swift */; };
 		0D2C4F4B1B2A00C20090765F /* XCTestCase-Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D2C4F491B2A00C20090765F /* XCTestCase-Ext.swift */; };
 		0D746A4F1AF7FD3C006EEDA2 /* FutureFIFO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D746A4E1AF7FD3C006EEDA2 /* FutureFIFO.swift */; };

--- a/FutureKit/Future.swift
+++ b/FutureKit/Future.swift
@@ -641,7 +641,7 @@ public class Future<T> : FutureProtocol{
     
     can only be used to a create a Future that should always succeed.
     */
-    public init(_ executor : Executor, block: () throws -> T) {
+    public init(_ executor : Executor = .Immediate, block: () throws -> T) {
         let block = executor.callbackBlockFor { () -> Void in
             do {
                 let r = try block()
@@ -662,7 +662,7 @@ public class Future<T> : FutureProtocol{
     
     the block can return a value of .CompleteUsing(Future<T>) if it wants this Future to complete with the results of another future.
     */
-    public init(_ executor : Executor, block: () throws -> Completion<T>) {
+    public init(_ executor : Executor = .Immediate, block: () throws -> Completion<T>) {
         executor.execute { () -> Void in
             do {
                 self.completeWith(try block())
@@ -673,25 +673,6 @@ public class Future<T> : FutureProtocol{
             }
         }
     }
-
-
-    /**
-    Creates a future by executes block inside of an Executor, and when it's complete, sets the completion = block()
-    
-    can be used to create a Future that may succeed or fail.
-    
-    the block can return a value of .CompleteUsing(Future<T>) if it wants this Future to complete with the results of another future.
-    */
-    public init(block: () throws -> Completion<T>) {
-        do {
-            self.completeWith(try block())
-        }
-        catch {
-            self.completeWith(.Fail(error))
-            
-        }
-    }
-    
 
     /**
         will complete the future and cause any registered callback blocks to be executed.

--- a/FutureKit/Future.swift
+++ b/FutureKit/Future.swift
@@ -1350,18 +1350,62 @@ public class Future<T> : FutureProtocol{
     
     If the target is completed with a .Fail, then the block will be executed using the supplied Executor.  
     
-    This method does **not** return a new Future.  If you need a new future, than use `onComplete()` instead.
+    This method returns a new Future.  Which is identical to the depedent Future, with the added Failure handler, that will execute before the Future completes.
+     Failures are still forwarded.  If you need to create side effects on errors, consider onComplete or mapError
     
     - parameter executor: an Executor to use to execute the block when it is ready to run.
     - parameter block: a block can process the error of a future.
     */
     public final func onFail(executor : Executor = .Primary,
-        block:(error:ErrorType)-> Void)
+        block:(error:ErrorType)-> Void) -> Future<T>
     {
-        self.onComplete(executor) { (result) -> Void in
+        return self.onComplete(executor) { (result) -> Completion<T> in
             if (result.isFail) {
                 block(error: result.error)
             }
+            return result.asCompletion()
+        }
+    }
+
+    /**
+     takes a block and executes it iff the target is completed with a .Fail
+     
+     If the target is completed with a .Fail, then the block will be executed using the supplied Executor.
+     
+     This method returns a new Future.  Failures can be be remapped to different Completions.  (Such as consumed or ignored or retried via returning .CompleteUsing()
+     
+     - parameter executor: an Executor to use to execute the block when it is ready to run.
+     - parameter block: a block can process the error of a future.
+     */
+    public final func onFail(executor : Executor = .Primary,
+        block:(error:ErrorType)-> Completion<T>) -> Future<T>
+    {
+        return self.onComplete(executor) { (result) -> Completion<T> in
+            if (result.isFail) {
+                return block(error: result.error)
+            }
+            return result.asCompletion()
+        }
+    }
+
+    /**
+     takes a block and executes it iff the target is completed with a .Fail
+     
+     If the target is completed with a .Fail, then the block will be executed using the supplied Executor.
+     
+     This method returns a new Future.  Failures can be be remapped to different Completions.  (Such as consumed or ignored or retried via returning .CompleteUsing()
+     
+     - parameter executor: an Executor to use to execute the block when it is ready to run.
+     - parameter block: a block can process the error of a future.
+     */
+    public final func onFail(executor : Executor = .Primary,
+        block:(error:ErrorType)-> Future<T>) -> Future<T>
+    {
+        return self.onComplete(executor) { (result) -> Completion<T> in
+            if (result.isFail) {
+                return .CompleteUsing(block(error: result.error))
+            }
+            return result.asCompletion()
         }
     }
 
@@ -1370,40 +1414,138 @@ public class Future<T> : FutureProtocol{
     
     If the target is completed with a .Cancelled, then the block will be executed using the supplied Executor.  
     
-    This method does **not** return a new Future.  If you need a new future, than use `onComplete()` instead.
-    
+     This method returns a new Future.  Cancellations
+     
     - parameter executor: an Executor to use to execute the block when it is ready to run.
     - parameter block: a block takes the canceltoken returned by the target Future and returns the completion value of the returned Future.
     */
-    public final func onCancel(executor : Executor = .Primary, block:()-> Void)
+    public final func onCancel(executor : Executor = .Primary, block:()-> Void) -> Future<T>
     {
-        self.onComplete(executor) { (result) -> Void in
+        return self.onComplete(executor) { (result) -> Completion<T> in
             if (result.isCancelled) {
                 block()
             }
+            return result.asCompletion()
         }
     }
 
+    /**
+     takes a block and executes it iff the target is completed with a .Cancelled
+     
+     If the target is completed with a .Cancelled, then the block will be executed using the supplied Executor.
+     
+     This method returns a new Future.  Cancellations
+     
+     - parameter executor: an Executor to use to execute the block when it is ready to run.
+     - parameter block: a block takes the canceltoken returned by the target Future and returns the completion value of the returned Future.
+     */
+    public final func onCancel(executor : Executor = .Primary, block:()-> Completion<T>) -> Future<T>
+    {
+        return self.onComplete(executor) { (result) -> Completion<T> in
+            if (result.isCancelled) {
+                return block()
+            }
+            return result.asCompletion()
+        }
+    }
+    /**
+     takes a block and executes it iff the target is completed with a .Cancelled
+     
+     If the target is completed with a .Cancelled, then the block will be executed using the supplied Executor.
+     
+     This method returns a new Future.  Cancellations
+     
+     - parameter executor: an Executor to use to execute the block when it is ready to run.
+     - parameter block: a block takes the canceltoken returned by the target Future and returns the completion value of the returned Future.
+     */
+    public final func onCancel(executor : Executor = .Primary, block:()-> Future<T>) -> Future<T>
+    {
+        return self.onComplete(executor) { (result) -> Completion<T> in
+            if (result.isCancelled) {
+                return .CompleteUsing(block())
+            }
+            return result.asCompletion()
+        }
+    }
+
+    
     /*:
     takes a block and executes it iff the target is completed with a .Fail or .Cancel
     
     If the target is completed with a .Fail, then the block will be executed using the supplied Executor.
     If the target is completed with a .Cancel, then the block will be executed using the supplied Executor.
     
-    This method does **not** return a new Future.  If you need a new future, than use `onComplete()` instead.
+    This method returns a new Future.  Which is identical to the depedent Future, with the added Fail/Cancel handler, that will execute after the dependent completes.
+    Cancelations and Failures are still forwarded.
     
     - parameter executor: an Executor to use to execute the block when it is ready to run.
     - parameter block: a block can process the error of a future.  error will be nil when the Future was canceled
     */
     public final func onFailorCancel(executor : Executor = .Primary,
-        block:(result:FutureResult<T>)-> Void)
+        block:(FutureResult<T>)-> Void) -> Future<T>
     {
-        self.onComplete(executor) { (result) -> Void in
-            if (result.isFail || result.isCancelled) {
-                block(result: result)
+        return self.onComplete(executor) { (result) -> Completion<T> in
+            switch result {
+            case .Fail, .Cancelled:
+                block(result)
+            case .Success(_):
+                break
+            }
+            return result.asCompletion()
+        }
+    }
+ 
+    
+    /*:
+    takes a block and executes it iff the target is completed with a .Fail or .Cancel
+    
+    If the target is completed with a .Fail, then the block will be executed using the supplied Executor.
+    If the target is completed with a .Cancel, then the block will be executed using the supplied Executor.
+    
+    This method returns a new Future.  Which is identical to the depedent Future, with the added Fail/Cancel handler, that will execute after the dependent completes.
+    Cancelations and Failures are still forwarded.
+    
+    - parameter executor: an Executor to use to execute the block when it is ready to run.
+    - parameter block: a block can process the error of a future.  error will be nil when the Future was canceled
+    */
+    public final func onFailorCancel(executor : Executor = .Primary,
+        block:(FutureResult<T>)-> Completion<T>) -> Future<T>
+    {
+        return self.onComplete(executor) { (result) -> Completion<T> in
+            switch result {
+                case .Fail, .Cancelled:
+                    return block(result)
+                case let .Success(value):
+                    return .Success(value)
             }
         }
     }
+    
+    /*:
+    takes a block and executes it iff the target is completed with a .Fail or .Cancel
+    
+    If the target is completed with a .Fail, then the block will be executed using the supplied Executor.
+    If the target is completed with a .Cancel, then the block will be executed using the supplied Executor.
+    
+    This method returns a new Future.  Which is identical to the depedent Future, with the added Fail/Cancel handler, that will execute after the dependent completes.
+    Cancelations and Failures are still forwarded.
+    
+    - parameter executor: an Executor to use to execute the block when it is ready to run.
+    - parameter block: a block can process the error of a future.  error will be nil when the Future was canceled
+    */
+    public final func onFailorCancel(executor : Executor = .Primary,
+        block:(FutureResult<T>)-> Future<T>) -> Future<T>
+    {
+        return self.onComplete(executor) { (result) -> Completion<T> in
+            switch result {
+            case .Fail, .Cancelled:
+                return .CompleteUsing(block(result))
+            case let .Success(value):
+                return .Success(value)
+            }
+        }
+    }
+
     
     /**
     takes a block and executes it iff the target is completed with a .Success

--- a/FutureKitTests/PromiseTests.swift
+++ b/FutureKitTests/PromiseTests.swift
@@ -718,8 +718,10 @@ class PromiseTests: FKTestCase {
 
     class func testsFor<T : Equatable>(result:T, result2:T) -> [BlockBasedTest] {
         
+        let opQueue = NSOperationQueue()
+        opQueue.maxConcurrentOperationCount = 2
         
-        let custom : Executor.CustomCallBackBlock = { (callback) -> Void in
+/*        let custom : Executor.CustomCallBackBlock = { (callback) -> Void in
             Executor.Background.execute {
                 Executor.Main.execute {
                     callback()
@@ -727,8 +729,6 @@ class PromiseTests: FKTestCase {
             }
         }
         
-        let opQueue = NSOperationQueue()
-        opQueue.maxConcurrentOperationCount = 2
         
         let q = dispatch_queue_create("custom q", DISPATCH_QUEUE_CONCURRENT)
         
@@ -745,7 +745,7 @@ class PromiseTests: FKTestCase {
             .StackCheckingImmediate,
             .OperationQueue(opQueue),
             .Custom(custom),
-            .Queue(q)]
+            .Queue(q)] */
 
         let quick_executors_list : [Executor] = [
             .MainAsync,
@@ -753,7 +753,7 @@ class PromiseTests: FKTestCase {
             .Current,
             .Immediate]
 
-        let future_executors : [Executor] = [.MainAsync, .MainImmediate]
+//        let future_executors : [Executor] = [.MainAsync, .MainImmediate]
 
         
         var blockTests = [BlockBasedTest]()
@@ -837,9 +837,7 @@ class PromiseTests: FKTestCase {
         let success: () = ()
         
         let completeExpectation = self.expectationWithDescription("Future.onComplete")
-//        let successExpectation = self.expectationWithDescription("Future.onSuccess")
-        let anySuccessExpectation = self.expectationWithDescription("Future.onAnySuccess")
-        
+        let successExpectation = self.expectationWithDescription("Future.onSuccess")
         
         f.onComplete(futureExecutor) { (completion) -> Void in
             
@@ -854,16 +852,11 @@ class PromiseTests: FKTestCase {
         
         // TODO: Can we get this to compile?
         
-/*        f.onSuccess(futureExecutor) { (result:()) -> Void in
+        f.onSuccess(futureExecutor) { (result:()) -> Void in
             
             successExpectation.fulfill()
             
-        } */
-        f.onAnySuccess(futureExecutor) { (result) -> Void in
-            XCTAssert(result is Void, "Didn't get expected success value \(success)")
-            anySuccessExpectation.fulfill()
         }
-        
         f.onFail(futureExecutor) { (error) -> Void in
             XCTFail("unexpectad onFail error \(error)")
             
@@ -886,7 +879,6 @@ class PromiseTests: FKTestCase {
         
         let completeExpectation = self.expectationWithDescription("Future.onComplete")
         let successExpectation = self.expectationWithDescription("Future.onSuccess")
-        let anySuccessExpectation = self.expectationWithDescription("Future.onAnySuccess")
         
         
         f.onComplete(futureExecutor) { (result) -> Void in
@@ -906,13 +898,6 @@ class PromiseTests: FKTestCase {
             successExpectation.fulfill()
             
         }
-        f.onAnySuccess(futureExecutor) { (result) -> Void in
-            let r = result as! T
-            XCTAssert(r == success, "Didn't get expected success value \(success)")
-            anySuccessExpectation.fulfill()
-            
-        }
-        
         f.onFail(futureExecutor) { (error) -> Void in
             XCTFail("unexpectad onFail error \(error)")
             


### PR DESCRIPTION
onFail, onCancel and onFailOrCancel now will return Futures (but won't let you return a new Success type, the new Futures MUST be identical to the dependent Future.

Removed some legacy tests for the departed onAnySucess()

