### PR TITLE
Remove OSSpinLockSynchronization

### DIFF
--- a/FutureKit/Future.swift
+++ b/FutureKit/Future.swift
@@ -35,7 +35,7 @@ public struct GLOBAL_PARMS {
     static let CURRENT_EXECUTOR_PROPERTY = "FutureKit.Executor.Current"
     static let STACK_CHECKING_MAX_DEPTH = 20
     
-    public static var LOCKING_STRATEGY : SynchronizationType = .OSSpinLock
+    public static var LOCKING_STRATEGY : SynchronizationType = .PThreadMutex
     
 }
 

--- a/FutureKitTests/LockPerformanceTests.swift
+++ b/FutureKitTests/LockPerformanceTests.swift
@@ -202,7 +202,7 @@ class LockPerformanceTests: BlockBasedTestCase {
             thread.start()
         }
         
-        self.expectationTestForFutureSuccess("threads", future: FutureBatchOf(f:futures).future)
+        self.expectationTestForFutureSuccess("threads", future: FutureBatchOf(futures:futures).future)
         self.waitForExpectationsWithTimeout(600, handler: nil)
     }
     


### PR DESCRIPTION
## Summary

This pull request removes OSSpinLock as a supported synchronization mechanism.

Additionally, the default locking strategy is changed from OSSpinLock to PThreadMutex.

## Motivation

There's a post on the swift-dev mailing list from Dec 14, where John McCall of Apple explicitly states that [using OSSpinLock on iOS is illegal.](https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20151214/000321.html)

Later, David Smith (also from Apple) [stated on Twitter](https://twitter.com/Catfish_Man/status/676851988596809728) that this is not confined to iOS but also affects OS X due to the throttling and priority shuffling done on the new 12" MacBook.

Apparently the issue is that lock acquisition from a high priority thread may fail indefinitely in case of a priority inversion, where the lock is already held by a low priority thread. The spinning done by the higher priority thread to acquire the lock can prevent the low priority thread from ever completing its work and releasing the lock. The result is effectively a deadlock.

A more in depth discussion on the topic [can be found here.](http://engineering.postmates.com/Spinlocks-Considered-Harmful-On-iOS/)

PThreadMutex was chosen as the new default as it is reportedly the underlying mechanism used to implement NSLock, but [experimentally it has a slightly smaller overhead.](http://perpendiculo.us/2009/09/synchronized-nslock-pthread-osspinlock-showdown-done-right/) 

## Implications

Existing code relying on the default locking strategy is likely to see a minor performance hit on the locking/unlocking operations.
