### PR TITLE
Use specified executor in FutureFIFO

### DIFF
--- a/FutureKit/FutureFIFO.swift
+++ b/FutureKit/FutureFIFO.swift
@@ -41,7 +41,7 @@ public class FutureFIFO {
     // If you care about the Result of specific committed block, you can add a dependency to the Task returned from this function
     public func add<T>(executor: Executor = .Primary, operation: () -> Future<T>) -> Future<T> {
     
-        let t = self.lastFuture.onComplete { _ in
+        let t = self.lastFuture.onComplete(executor) { _ in
             return operation()
         }
         self.lastFuture = t.mapAs()


### PR DESCRIPTION
`FutureFIFO.add` did not invoke the operation block on the supplied executor.