### PR TITLE
add public init for ArrayWithFastLockAccess

### DIFF
--- a/FutureKit/Synchronization.swift
+++ b/FutureKit/Synchronization.swift
@@ -1110,6 +1110,9 @@ public class DictionaryWithBarrierAccess<Key : Hashable, Value> : DictionaryWith
 
 public class ArrayWithFastLockAccess<T> : ArrayWithSynchronization<T,SynchronizationType.LightAndFastSyncType> {
     
+    override public init() {
+        super.init(array: Array<T>(), SynchronizationType.LightAndFastSyncType())
+    }
     
 }
 


### PR DESCRIPTION
fix for the error below when trying ArrayWithFastLockAccess<ItemType>()

error: 'ArrayWithFastLockAccess<ItemType>' cannot be constructed because it has no accessible initializers