### PR TITLE
Exclude invalid paths in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,5 +2,19 @@ import PackageDescription
 
 let package = Package(
     name: "FutureKit",
-    dependencies: []
+    dependencies: [],
+    exclude: [
+      "docs",
+      "FutureKit/FutureKit.h",
+      "FutureKit/Utils/ObjectiveCExceptionHandler.h",
+      "FutureKit/Utils/ObjectiveCExceptionHandler.m",
+      "FutureKit iOS Testing AppTests",
+      "FutureKit iOS Tests",
+      "FutureKit OSX Tests",
+      "FutureKit tvOS",
+      "FutureKit tvOSTests",
+      "FutureKit watchOS",
+      "FutureKit.xcworkspace",
+      "FutureKitTests"
+    ]
 )


### PR DESCRIPTION
Fixed the following issues when using FutureKit as a Swift Package Manager Package:

```
error: the module at Packages/FutureKit-3.0.0/docs does not contain any source files
fix: either remove the module folder, or add a source file to the module

error: the module at Packages/FutureKit-3.0.0/FutureKit contains mixed language source files
fix: use only a single language within a module

error: the module at FutureKit iOS Testing AppTests has an invalid name ('FutureKit iOS Testing AppTests'): the name of a non-test module has a ‘Tests’ suffix
fix: rename the module at ‘FutureKit iOS Testing AppTests’ to not have a ‘Tests’ suffix

error: the module at FutureKit iOS Tests has an invalid name ('FutureKit iOS Tests'): the name of a non-test module has a ‘Tests’ suffix
fix: rename the module at ‘FutureKit iOS Tests’ to not have a ‘Tests’ suffix

error: the module at FutureKit OSX Tests has an invalid name ('FutureKit OSX Tests'): the name of a non-test module has a ‘Tests’ suffix
fix: rename the module at ‘FutureKit OSX Tests’ to not have a ‘Tests’ suffix

error: the module at Packages/FutureKit-3.0.0/FutureKit tvOS does not contain any source files
fix: either remove the module folder, or add a source file to the module

error: the module at FutureKit tvOSTests has an invalid name ('FutureKit tvOSTests'): the name of a non-test module has a ‘Tests’ suffix
fix: rename the module at ‘FutureKit tvOSTests’ to not have a ‘Tests’ suffix

error: the module at Packages/FutureKit-3.0.0/FutureKit watchOS does not contain any source files
fix: either remove the module folder, or add a source file to the module

error: the module at Packages/FutureKit-3.0.0/FutureKit.xcworkspace does not contain any source files
fix: either remove the module folder, or add a source file to the module

error: the module at FutureKitTests has an invalid name ('FutureKitTests'): the name of a non-test module has a ‘Tests’ suffix
fix: rename the module at ‘FutureKitTests’ to not have a ‘Tests’ suffix
```