### PR TITLE
Make 'onComplete' discardable.

### DIFF
--- a/FutureKit/Future.swift
+++ b/FutureKit/Future.swift
@@ -1140,7 +1140,7 @@ open class Future<T> : FutureProtocol {
     - returns: a new Future that returns results of type __Type  (Future<__Type>)
     
     */
-    public final func onComplete<C: CompletionType>(_ executor : Executor,block:@escaping (_ result:FutureResult<T>) throws -> C) -> Future<C.T> {
+    @discardableResult public final func onComplete<C: CompletionType>(_ executor : Executor,block:@escaping (_ result:FutureResult<T>) throws -> C) -> Future<C.T> {
         
         let (promise, completionCallback) = self.createPromiseAndCallback(block)
         let block = executor.callbackBlockFor(completionCallback)
@@ -1194,7 +1194,7 @@ extension FutureProtocol {
         return (self,self.getCancelToken())
     }
     
-    public final func onComplete<C: CompletionType>(_ block: @escaping (FutureResult<T>) throws -> C) -> Future<C.T> {
+    @discardableResult public final func onComplete<C: CompletionType>(_ block: @escaping (FutureResult<T>) throws -> C) -> Future<C.T> {
         return self.onComplete(.primary,block:block)
     }
 
@@ -1209,7 +1209,7 @@ extension FutureProtocol {
     - parameter block: a block that will execute when this future completes, a `.Success(result)` using the return value of the block.
     - returns: a new Future that returns results of type __Type
     */
-    public final func onComplete<__Type>(_ executor: Executor = .primary, _ block:@escaping (_ result:FutureResult<T>) throws -> __Type) -> Future<__Type> {
+    @discardableResult public final func onComplete<__Type>(_ executor: Executor = .primary, _ block:@escaping (_ result:FutureResult<T>) throws -> __Type) -> Future<__Type> {
         return self.onComplete(executor) { (result) -> Completion<__Type> in
             return .success(try block(result))
         }


### PR DESCRIPTION
Looking at the playground it includes an unused result after a call to `onComplete`, and that's the use case I'm using it for in my code.